### PR TITLE
Fix an issue where the speciality appeared as 'null' when retrieving …

### DIFF
--- a/backend/services/artisanService.js
+++ b/backend/services/artisanService.js
@@ -52,13 +52,15 @@ module.exports = {
         {
           model: Speciality,
           as: "speciality",
+          where: { category_id: categoryId },
           include: [
             {
               model: Category,
               as: "category",
-              where: { category_id: categoryId },
+              attributes: ["category"],
             },
           ],
+          attributes: ["speciality"],
         },
         { model: City, as: "city", attributes: ["city"] },
       ],


### PR DESCRIPTION
Changes made:
- Moved the `where: { category_id: categoryId }` condition from the `categories` include to the  `specialities` include.
- Specified `attributes` to display only relevant fields (`speciality` and `category`).
- Tested the `/artisans/:category` route on Postman to confirm the speciality is now correctly returned.

**Example response:**

```
[
    {
        "name": "Orville Salmons",
        "note": "5.0",
        "speciality": {
            "speciality": "Chauffagiste",
            "category": {
                "category": "Bâtiment"
            }
        },
        "city": {
            "city": "Evian"
        }
    },
    {
        "name": "Mont Blanc Electricité",
        "note": "4.5",
        "speciality": {
            "speciality": "Electricien",
            "category": {
                "category": "Bâtiment"
            }
        },
        "city": {
            "city": "Chamonix"
        }
    },
    {
        "name": "Boutot & fils",
        "note": "4.7",
        "speciality": {
            "speciality": "Menuisier",
            "category": {
                "category": "Bâtiment"
            }
        },
        "city": {
            "city": "Bourg-en-Bresse"
        }
    },
    {
        "name": "Vallis Bellemare",
        "note": "4.0",
        "speciality": {
            "speciality": "Plombier",
            "category": {
                "category": "Bâtiment"
            }
        },
        "city": {
            "city": "Vienne"
        }
    }
]
```